### PR TITLE
Added support for customization of block IP in config.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+config.py
+__pycache__/
+testdata/*.csv

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ An example file with errors is in testdata/testfile.txt.
 
 
 We give the status of each IOC:
-1. Blocked: Blocked by UltraDDR
-2. Not Blocked: Not blocked by UltraDDR
+1. Blocked: Blocked by UltraDDR.
+2. Not Blocked: Not blocked by UltraDDR.
 3. NXDOMAIN: The domain no longer exists or the FQDN inside of it does not exist.
 4. PTR: For IP addresses, we query for PTR but UltraDDR doesn't block like it does for the other IOCs.
-5. Error: Anything not in the above list
+5. Error: Anything not in the above list.
 
 
 ### To Use:
@@ -76,3 +76,12 @@ options:
                         Checker' and can be configured in config.py
 
 ```
+
+### To Configure:
+
+The config.py file supports the following configurations:
+
+1. `ProviderURL` (required) is the URL the IOC Checker uses to make DoH queries to UltraDDR. 
+2. `ClientID` (required) associates the DNS queries made by the tool with your UltraDDR account.
+3. `BlockIP` (required) is the sinkhole IP address returned by UltraDDR and is used by the tool to determine if an FQDN was blocked.
+4. `DeviceID` (optional) helps you identify the queries made by the IOC Checker tool when reviewing logs in UltraDDR.

--- a/config.py.example
+++ b/config.py.example
@@ -7,6 +7,7 @@ class Config:
     def __init__(self):
         self.ProviderURL = "https://rcsv.ddr.ultradns.com/dns-query?name="
         self.ClientID = 'CHANGEME'
+        self.BlockIP = 'CHANGEME'
         self.DeviceID = 'UltraDDR-IOC-Checker'
 
 

--- a/ultraddr-ioc-checker.py
+++ b/ultraddr-ioc-checker.py
@@ -10,7 +10,7 @@ import re
 from joblib import Parallel, delayed
 import csv
 import random
-
+import ipaddress
 
 if not os.path.exists('config.py'):
     exit('Error, you haven\'t set up a configuration.\nPlease copy config.py.example to config.py and change the ClientID.')
@@ -19,6 +19,13 @@ else:
     config = config.Config()
     if config.ClientID == 'CHANGEME':
         exit('Error, you haven\'t set up a ClientID in config.py.\nPlease fix and re-run.')
+    
+    config.BlockIP = config.BlockIP.strip()
+    
+    try:
+        ipaddress.ip_address(config.BlockIP)
+    except ValueError:
+        exit('Error, you have specified an invalid IP address (%s) in your config.py.' % config.BlockIP)
 
 generationdate = datetime.datetime.now().strftime("%Y.%m.%d %I:%M:%S %p")
 today = datetime.datetime.now().strftime("%Y-%m-%d")
@@ -61,7 +68,7 @@ parser.add_argument('--random', '-r', dest='random', type=int, help='Pick X rand
 parser.add_argument('--device', '-d', type=str, help='Send this name as the DeviceID.  Default is \
                     \'DDR-IOC-Checker\' and can be configured in config.py. Use \'random\' to use a random set of \
                     device names')
-args = parser.parse_args()
+args = parser.parse_args() 
 # ----------End Input Validation----------
 
 
@@ -247,7 +254,7 @@ class IOCName:
         self.rawresults = json.dumps(ddr_results)
         if 'Answer' in ddr_results.keys():
             print(json.dumps(ddr_results['Answer'][0]['data'], indent=4))
-            if ddr_results['Answer'][0]['data'] == '20.13.128.62':
+            if ddr_results['Answer'][0]['data'] == config.BlockIP:
                 self.status = 'Blocked'
                 print('Blocked')
             else:


### PR DESCRIPTION
Added support for customized block IP configurations.  The block IP is the sinkhole IP returned by UltraDDR for FQDNs that are blocked.  The UltraDDR-IOC-Checker uses this determine if an FQDN was blocked. 

Updated README.md to include a section on configuration of config.py

Added a .gitignore to prevent leakage of sensitive data in config.py and remove .csv reports generated by running UltraDDR-IOC-Checker.